### PR TITLE
Fix InventoryBar type import causing blank screen

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,5 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import Header from './components/Header';
-import InventoryBar from './components/inventory/InventoryBar';
 import BuildingsPanel from './components/BuildingsPanel';
 import SeasonClock from './components/SeasonClock';
 import StorageSummary from './components/StorageSummary';

--- a/src/components/BuildingsPanel.tsx
+++ b/src/components/BuildingsPanel.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useGame } from '../store/gameStore';
 import { BUILDINGS, type BuildingId } from '../data/buildings';
 

--- a/src/components/GranaryPanel.tsx
+++ b/src/components/GranaryPanel.tsx
@@ -1,7 +1,5 @@
-import React from 'react';
 import { useGame } from '../store/gameStore';
 import { BUILDINGS } from '../data/buildings';
-import { ITEMS } from '../data/items';
 
 export default function GranaryPanel() {
   const canAfford = useGame(s=>s.canAfford);

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useGame } from '../store/gameStore';
 
 export default function Header() {

--- a/src/components/SeasonClock.tsx
+++ b/src/components/SeasonClock.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useGame } from '../store/gameStore';
 
 function fmt(ms: number) {

--- a/src/components/StorageSummary.tsx
+++ b/src/components/StorageSummary.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import { useGame } from '../store/gameStore';
 import { ITEM_ORDER, ITEMS } from '../data/items';
 

--- a/src/components/WarehousesPanel.tsx
+++ b/src/components/WarehousesPanel.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useGame } from '../store/gameStore';
 import { BUILDINGS } from '../data/buildings';
 

--- a/src/components/inventory/InventoryBar.tsx
+++ b/src/components/inventory/InventoryBar.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import InventoryItem from "./InventoryItem";
 
 const ICONS: Record<string, string> = {

--- a/src/components/inventory/InventoryBarContainer.tsx
+++ b/src/components/inventory/InventoryBarContainer.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import InventoryBar, { InventoryRecord } from "./InventoryBar";
+import InventoryBar from "./InventoryBar";
+import type { InventoryRecord } from "./InventoryBar";
 import { useGame } from "../../store/gameStore";
 import { ITEM_ORDER, ITEMS } from "../../data/items";
 

--- a/src/components/inventory/InventoryItem.tsx
+++ b/src/components/inventory/InventoryItem.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 type Props = {
   iconSrc: string;
   label: string;

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -53,11 +53,11 @@ function makeInitialInventory(): Inventory {
 }
 
 function makeInitialMax(): MaxByItem {
-  const max: MaxByItem = {} as any;
+  const max: Partial<MaxByItem> = {};
   for (const id of ITEM_ORDER) {
     max[id] = ITEMS[id].baseMax ?? 0;
   }
-  return max;
+  return max as MaxByItem;
 }
 
 function makeInitialBuildings(): Record<BuildingId, BuildingState> {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,3 @@
+/// <reference types="vite/client" />
+
+declare module '*.css';


### PR DESCRIPTION
## Summary
- switch InventoryBarContainer to a type-only InventoryRecord import so the component no longer tries to load a missing runtime export
- add Vite CSS module declarations and clean up unused React imports that were breaking the TypeScript build
- tidy the game store initialization helpers and remove unused imports

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd85084fcc8332abdba4e9d79672da